### PR TITLE
SpectrumWidget: Plot individual conformers

### DIFF
--- a/aiidalab_ispg/spectrum.py
+++ b/aiidalab_ispg/spectrum.py
@@ -469,6 +469,7 @@ class SpectrumWidget(ipw.VBox):
             kernel, width, energy_unit
         )
         y_total *= self.conformer_transitions[0]["weight"]
+        y_stick *= self.conformer_transitions[0]["weight"]
 
         # Plot individual conformers, if there is more than one
         nconf = len(self.conformer_transitions)
@@ -484,10 +485,13 @@ class SpectrumWidget(ipw.VBox):
                 x, y, xs, ys = spec.get_spectrum(
                     kernel, width, energy_unit, x_min=x_min, x_max=x_max
                 )
-                x_stick = np.concatenate((x_stick, xs))
-                y_stick = np.concatenate((y_stick, ys))
                 y *= conf["weight"]
                 y_total += y
+
+                ys *= conf["weight"]
+                x_stick = np.concatenate((x_stick, xs))
+                y_stick = np.concatenate((y_stick, ys))
+
                 if self.conformer_toggle.value:
                     self._plot_conformer(x, y, conf_id, update=False)
 

--- a/aiidalab_ispg/spectrum.py
+++ b/aiidalab_ispg/spectrum.py
@@ -278,7 +278,7 @@ class SpectrumWidget(ipw.VBox):
         )
         self.download_btn.on_click(self._download_spectrum)
 
-        layout = ipw.Layout(justify_content="space-between")
+        # layout = ipw.Layout(justify_content="space-between")
         self.conformer_viewer = TrajectoryDataViewer(configuration_tabs=[])
         ipw.dlink(
             (self.conformer_viewer, "selected_structure_id"),
@@ -292,12 +292,14 @@ class SpectrumWidget(ipw.VBox):
                 ipw.HBox(
                     [
                         self.figure,
-                        ipw.VBox(
-                            [self.spectrum_controls, self.conformer_viewer],
-                            layout=layout,
-                        ),
+                        self.spectrum_controls,
+                        # ipw.VBox(
+                        #    [self.spectrum_controls, self.conformer_viewer],
+                        #    layout=layout,
+                        # ),
                     ],
                 ),
+                self.conformer_viewer,
             ],
             **kwargs,
         )

--- a/aiidalab_ispg/spectrum.py
+++ b/aiidalab_ispg/spectrum.py
@@ -278,7 +278,7 @@ class SpectrumWidget(ipw.VBox):
         )
         self.download_btn.on_click(self._download_spectrum)
 
-        # layout = ipw.Layout(justify_content="space-between")
+        layout = ipw.Layout(justify_content="space-between")
         self.conformer_viewer = TrajectoryDataViewer(configuration_tabs=[])
         ipw.dlink(
             (self.conformer_viewer, "selected_structure_id"),
@@ -292,14 +292,12 @@ class SpectrumWidget(ipw.VBox):
                 ipw.HBox(
                     [
                         self.figure,
-                        self.spectrum_controls,
-                        # ipw.VBox(
-                        #    [self.spectrum_controls, self.conformer_viewer],
-                        #    layout=layout,
-                        # ),
+                        ipw.VBox(
+                            [self.spectrum_controls, self.conformer_viewer],
+                            layout=layout,
+                        ),
                     ],
                 ),
-                self.conformer_viewer,
             ],
             **kwargs,
         )

--- a/aiidalab_ispg/spectrum.py
+++ b/aiidalab_ispg/spectrum.py
@@ -278,7 +278,7 @@ class SpectrumWidget(ipw.VBox):
         )
         self.download_btn.on_click(self._download_spectrum)
 
-        layout = ipw.Layout(justify_content="space-between")
+        layout = ipw.Layout(justify_content="flex-start")
         self.conformer_viewer = TrajectoryDataViewer(configuration_tabs=[])
         ipw.dlink(
             (self.conformer_viewer, "selected_structure_id"),
@@ -605,10 +605,11 @@ class SpectrumWidget(ipw.VBox):
     def enable_controls(self):
         self.download_btn.disabled = False
         self.stick_toggle.disabled = False
-        self.conformer_toggle.disabled = False
         self.energy_unit_selector.disabled = False
         self.width_slider.disabled = False
         self.kernel_selector.disabled = False
+        if len(self.conformer_transitions) > 1:
+            self.conformer_toggle.disabled = False
 
     def reset(self):
         with self.hold_trait_notifications():

--- a/aiidalab_ispg/spectrum.py
+++ b/aiidalab_ispg/spectrum.py
@@ -634,6 +634,7 @@ class SpectrumWidget(ipw.VBox):
         with self.hold_trait_notifications():
             self.transitions = None
             self.conformer_transitions = None
+            self.conformers = None
             self.smiles = None
             self.experimental_spectrum = None
 

--- a/aiidalab_ispg/spectrum.py
+++ b/aiidalab_ispg/spectrum.py
@@ -265,6 +265,7 @@ class SpectrumWidget(ipw.VBox):
         self.debug_output = ipw.Output()
 
         self.figure = self._init_figure(tools=self._TOOLS, tooltips=self._TOOLTIPS)
+        self.figure.layout = ipw.Layout(overflow="initial")
 
         self.download_btn = ipw.Button(
             description="Download spectrum",
@@ -290,7 +291,7 @@ class SpectrumWidget(ipw.VBox):
                     [
                         self.figure,
                         ipw.VBox([self.spectrum_controls, self.conformer_viewer]),
-                    ]
+                    ],
                 ),
             ],
             **kwargs,
@@ -435,8 +436,9 @@ class SpectrumWidget(ipw.VBox):
 
     def _hide_all_conformers(self):
         self._unhighlight_conformer()
-        for i in range(len(self.conformer_transitions)):
-            label = f"conformer_{i}"
+        f = self.figure.get_figure()
+        labels = [r.name for r in f.renderers]
+        for label in filter(lambda l: l.startswith("conformer_"), labels):
             # NOTE: Hiding does not seem to work
             # Removing without immediate figure update also does not work
             self.remove_line(label, update=True)
@@ -655,6 +657,7 @@ class SpectrumWidget(ipw.VBox):
     @traitlets.observe("conformer_transitions")
     def _observe_conformer_transitions(self, change):
         self.disable_controls()
+        self._hide_all_conformers()
         if change["new"] is None:
             return
         self._plot_spectrum(

--- a/aiidalab_ispg/steps.py
+++ b/aiidalab_ispg/steps.py
@@ -707,6 +707,8 @@ class ViewSpectrumStep(ipw.VBox, WizardAppWidgetStep):
         else:
             self.spectrum.smiles = None
 
+        self.spectrum.conformers = self.process.outputs.relaxed_structures
+
     def _update_header(self):
         if self.process is None:
             self.header.value = ""

--- a/aiidalab_ispg/steps.py
+++ b/aiidalab_ispg/steps.py
@@ -750,5 +750,6 @@ class ViewSpectrumStep(ipw.VBox, WizardAppWidgetStep):
     def _observe_process(self, change):
         if change["new"] == change["old"]:
             return
+        self.spectrum.reset()
         self._update_state()
         self._update_header()

--- a/aiidalab_ispg/steps.py
+++ b/aiidalab_ispg/steps.py
@@ -658,7 +658,6 @@ class ViewSpectrumStep(ipw.VBox, WizardAppWidgetStep):
         return transitions
 
     def _show_spectrum(self):
-
         if self.process is None or not self.process.is_finished_ok:
             return
 
@@ -676,16 +675,8 @@ class ViewSpectrumStep(ipw.VBox, WizardAppWidgetStep):
             }
             for conformer in self.process.outputs.spectrum_data.get_list()
         ]
-        self.spectrum.conformer_transitions = conformer_transitions
 
-        # Temporary hack to see old code
-        all_transitions = []
-        for conformer in self.process.outputs.spectrum_data.get_list():
-            all_transitions += self._wigner_output_to_transitions(conformer)
-        nconf = len(self.process.outputs.spectrum_data)
-        if nconf > 1:
-            all_transitions[-1]["geom_index"] = (nsample * nconf) - 1
-        # self.spectrum.transitions = all_transitions
+        self.spectrum.conformer_transitions = conformer_transitions
 
         if "smiles" in self.process.inputs.structure.extras:
             self.spectrum.smiles = self.process.inputs.structure.extras["smiles"]
@@ -700,7 +691,7 @@ class ViewSpectrumStep(ipw.VBox, WizardAppWidgetStep):
             self.spectrum.smiles = None
 
         if "relaxed_structures" in self.process.outputs:
-            self.spectrum.conformers = self.process.outputs.relaxed_structures
+            self.spectrum.conformer_structures = self.process.outputs.relaxed_structures
 
     def _update_header(self):
         if self.process is None:

--- a/aiidalab_ispg/steps.py
+++ b/aiidalab_ispg/steps.py
@@ -699,7 +699,8 @@ class ViewSpectrumStep(ipw.VBox, WizardAppWidgetStep):
         else:
             self.spectrum.smiles = None
 
-        self.spectrum.conformers = self.process.outputs.relaxed_structures
+        if "relaxed_structures" in self.process.outputs:
+            self.spectrum.conformers = self.process.outputs.relaxed_structures
 
     def _update_header(self):
         if self.process is None:

--- a/aiidalab_ispg/widgets.py
+++ b/aiidalab_ispg/widgets.py
@@ -132,10 +132,16 @@ class TrajectoryDataViewer(StructureDataViewer):
 
     # TODO: Do not subclass StructureDataViewer, but have it as a component
     trajectory = traitlets.Instance(Node, allow_none=True)
+    selected_structure_id = traitlets.Int(allow_none=True)
+
     _structures = []
     _energies = None
 
-    def __init__(self, trajectory=None, **kwargs):
+    def __init__(self, trajectory=None, configuration_tabs=None, **kwargs):
+
+        if configuration_tabs is None:
+            configuration_tabs = ["Selection", "Download"]
+
         # Trajectory navigator.
         self._step_selector = ipw.IntSlider(
             min=1,
@@ -146,6 +152,7 @@ class TrajectoryDataViewer(StructureDataViewer):
         self._step_selector.observe(self.update_selection, names="value")
 
         # Display energy if available
+        # TODO: Generalize this
         self._energy = ipw.HTML(
             value="Energy ",
             placeholder="Energy",
@@ -154,7 +161,7 @@ class TrajectoryDataViewer(StructureDataViewer):
         children = [ipw.HBox(children=[self._step_selector, self._energy])]
 
         super().__init__(
-            children=children, configuration_tabs=["Selection", "Download"], **kwargs
+            children=children, configuration_tabs=configuration_tabs, **kwargs
         )
 
         self.trajectory = trajectory
@@ -163,6 +170,7 @@ class TrajectoryDataViewer(StructureDataViewer):
         """Display selected structure"""
         index = change["new"] - 1
         self.structure = self._structures[index]
+        self.selected_structure_id = index
         # TODO: We should pass energy units as well somehow
         if self._energies is not None:
             self._energy.value = f"Energy = {self._energies[index]:.2f} eV"
@@ -171,6 +179,7 @@ class TrajectoryDataViewer(StructureDataViewer):
     def _update_trajectory(self, change):
         trajectory = change["new"]
         if trajectory is None:
+            self.structure = None
             self._step_selector.min = 1
             self._step_selector.max = 1
             self._step_selector.disabled = True

--- a/aiidalab_ispg/widgets.py
+++ b/aiidalab_ispg/widgets.py
@@ -180,6 +180,7 @@ class TrajectoryDataViewer(StructureDataViewer):
         trajectory = change["new"]
         if trajectory is None:
             self.structure = None
+            self.set_trait("displayed_structure", None)
             self._step_selector.min = 1
             self._step_selector.max = 1
             self._step_selector.disabled = True

--- a/atmospec.ipynb
+++ b/atmospec.ipynb
@@ -10,6 +10,17 @@
     "IPython.OutputArea.prototype._should_scroll = function(lines) {\n",
     "    return false;\n",
     "}\n",
+    "// Trying to fix Mol viewer inside accordion box,\n",
+    "// padding 15px is the default, reducing it did not help\n",
+    "var styles = `\n",
+    "    .p-Collapse-contents { \n",
+    "        padding: 15px;\n",
+    "    }\n",
+    "`\n",
+    "var styleSheet = document.createElement(\"style\")\n",
+    "styleSheet.innerText = styles\n",
+    "document.head.appendChild(styleSheet)\n",
+    "\n",
     "document.title = 'AiiDAlab ATMOSPEC app'"
    ]
   },
@@ -312,6 +323,7 @@
     "        ('Status & Detailed outputs', view_atmospec_work_chain_status_and_results_step),\n",
     "        ('UV/VIS Spectrum', view_spectrum_step),\n",
     "    ])\n",
+    "app.layout.padding = \"0px 0px 0px 0px\"\n",
     "\n",
     "# Reset all subsequent steps in case that a new structure is selected\n",
     "def _observe_structure_selection(change):\n",
@@ -358,6 +370,17 @@
     "app_with_work_chain_selector = ipw.VBox(children=[work_chain_selector, app])\n",
     "\n",
     "display(welcome_message, app_with_work_chain_selector,footer)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#acc = app.children[1]\n",
+    "#spec = acc.children[3]\n",
+    "#acc.layout.padding = \"0px\""
    ]
   }
  ],

--- a/atmospec.ipynb
+++ b/atmospec.ipynb
@@ -377,7 +377,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.9"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,

--- a/atmospec.ipynb
+++ b/atmospec.ipynb
@@ -323,7 +323,6 @@
     "        ('Status & Detailed outputs', view_atmospec_work_chain_status_and_results_step),\n",
     "        ('UV/VIS Spectrum', view_spectrum_step),\n",
     "    ])\n",
-    "app.layout.padding = \"0px 0px 0px 0px\"\n",
     "\n",
     "# Reset all subsequent steps in case that a new structure is selected\n",
     "def _observe_structure_selection(change):\n",

--- a/spectrum_widget.ipynb
+++ b/spectrum_widget.ipynb
@@ -68,9 +68,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#fig = widget.spectrum.figure.get_figure()\n",
-    "#for g in fig.renderers:\n",
-    "#    print(g)"
+    "fig = widget.spectrum.figure.get_figure()\n",
+    "for g in fig.renderers:\n",
+    "    print(g.name)\n",
+    "line = fig.select_one({\"name\": \"conformer_0\"})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13c7757d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#line.glyph.update(line_dash=\"solid\")\n",
+    "#line.data_source.data['x']\n",
+    "widget.spectrum.clean_figure()\n",
+    "#fig.renderers.remove('theory')"
    ]
   },
   {

--- a/spectrum_widget.ipynb
+++ b/spectrum_widget.ipynb
@@ -69,22 +69,9 @@
    "outputs": [],
    "source": [
     "fig = widget.spectrum.figure.get_figure()\n",
-    "for g in fig.renderers:\n",
-    "    print(g.name)\n",
-    "line = fig.select_one({\"name\": \"conformer_0\"})"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "13c7757d",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#line.glyph.update(line_dash=\"solid\")\n",
-    "#line.data_source.data['x']\n",
-    "widget.spectrum.clean_figure()\n",
-    "#fig.renderers.remove('theory')"
+    "#for g in fig.renderers:\n",
+    "#    print(g.name)\n",
+    "#line = fig.select_one({\"name\": \"conformer_0\"})"
    ]
   },
   {
@@ -112,9 +99,11 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "11d36291",
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "575c8ff1",
    "metadata": {},
+   "outputs": [],
    "source": [
     "### Testing spectrum widget against Newton-X reference "
    ]
@@ -122,7 +111,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a9ea1bd2",
+   "id": "e58c283c",
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
Closes #11. Code refactor stepping towards #42.

TODO:
- [x] Fix horizontal layout
- [x] Hide all conformers when switching between different structures
- [x] Add validation for `conformer_structures`, automatically turn StructureData to TrajectoryData
- [ ] Fix displaying conformer structure within Atmospec app
- [x] Fix unit conversions for conformers
- [x] Better scaling of sticks
- [x] Better handling of x_min and x_max

https://notebook.community/ipython/ipywidgets/docs/source/examples/Widget%20Styling
https://www.w3schools.com/CSSREF/tryit.php?filename=trycss3_justify-content3