### PR TITLE
Take screenshot as part of test teardown

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ python_requires = >=3.8
 # and publish a separate package to PyPi.
 install_requires =
     rdkit
-    aiidalab-widgets-base~=2.0.0b0
+    aiidalab-widgets-base[smiles]~=2.0.0b1
     aiida-orca @ git+https://github.com/danielhollas/aiida-orca.git@atmospec
     aiidalab_atmospec_workchain @ file:///home/jovyan/apps/aiidalab-ispg/workflows/
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,7 +75,7 @@ def selenium_driver(selenium, notebook_service, screenshot_dir):
 
     def _selenium_driver(nb_path, wait_time=5.0, screenshot_name=None):
         url, token = notebook_service
-        global final_screenshot_name
+        nonlocal final_screenshot_name
         final_screenshot_name = screenshot_name
         url_with_token = urljoin(
             url, f"apps/apps/aiidalab-ispg/{nb_path}?token={token}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -104,11 +104,11 @@ def generate_mol_from_smiles():
 def check_first_atom():
     def _select_first_atom(driver, atom_symbol):
         driver.find_element(
-            By.XPATH, "//label[text()='Select atoms:']/following-sibling::input"
+            By.XPATH, "//label[text()='Selected atoms:']/following-sibling::input"
         ).send_keys("1")
         driver.find_element(By.XPATH, '//button[text()="Apply selection"]').click()
         driver.find_element(
-            By.XPATH, f"//p[contains(text(),'Id: 1; Symbol: {atom_symbol};')]"
+            By.XPATH, f"//div[starts-with(text(),'Id: 1; Symbol: {atom_symbol};')]"
         )
 
     return _select_first_atom

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -125,12 +125,15 @@ def screenshot_dir():
 
 
 @pytest.fixture
-def final_screenshot(selenium, screenshot_dir):
-    ctx = {"name": ""}
-    yield ctx
-    if not ctx["name"]:
-        raise ValueError("You forgot to set the final screenshot name!")
-    selenium.get_screenshot_as_file(f"{screenshot_dir}/{ctx['name']}")
+def final_screenshot(request, screenshot_dir, selenium):
+    """Take screenshot at the end of the test.
+    Screenshot name is generated from the test function name
+    by stripping the 'test_' prefix
+    """
+    screenshot_name = f"{request.function.__name__[5:]}.png"
+    screenshot_path = Path.joinpath(screenshot_dir, screenshot_name)
+    yield
+    selenium.get_screenshot_as_file(screenshot_path)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -104,11 +104,11 @@ def generate_mol_from_smiles():
 def check_first_atom():
     def _select_first_atom(driver, atom_symbol):
         driver.find_element(
-            By.XPATH, "//label[text()='Selected atoms:']/following-sibling::input"
+            By.XPATH, "//label[text()='Select atoms:']/following-sibling::input"
         ).send_keys("1")
         driver.find_element(By.XPATH, '//button[text()="Apply selection"]').click()
         driver.find_element(
-            By.XPATH, f"//div[starts-with(text(),'Id: 1; Symbol: {atom_symbol};')]"
+            By.XPATH, f"//p[contains(text(),'Id: 1; Symbol: {atom_symbol};')]"
         )
 
     return _select_first_atom

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,13 +70,9 @@ def notebook_service(docker_ip, docker_services, aiidalab_exec, nb_user, appdir)
 
 
 @pytest.fixture(scope="function")
-def selenium_driver(selenium, notebook_service, screenshot_dir):
-    final_screenshot_name = None
-
-    def _selenium_driver(nb_path, wait_time=5.0, screenshot_name=None):
+def selenium_driver(selenium, notebook_service):
+    def _selenium_driver(nb_path, wait_time=5.0):
         url, token = notebook_service
-        nonlocal final_screenshot_name
-        final_screenshot_name = screenshot_name
         url_with_token = urljoin(
             url, f"apps/apps/aiidalab-ispg/{nb_path}?token={token}"
         )
@@ -89,9 +85,7 @@ def selenium_driver(selenium, notebook_service, screenshot_dir):
 
         return selenium
 
-    yield _selenium_driver
-    if final_screenshot_name is not None:
-        selenium.get_screenshot_as_file(f"{screenshot_dir}/{final_screenshot_name}")
+    return _selenium_driver
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,6 +75,7 @@ def selenium_driver(selenium, notebook_service, screenshot_dir):
 
     def _selenium_driver(nb_path, wait_time=5.0, screenshot_name=None):
         url, token = notebook_service
+        global final_screenshot_name
         final_screenshot_name = screenshot_name
         url_with_token = urljoin(
             url, f"apps/apps/aiidalab-ispg/{nb_path}?token={token}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -131,11 +131,12 @@ def screenshot_dir():
 
 
 @pytest.fixture
-def final_screenshot(request, selenium, screenshot_dir):
+def final_screenshot(selenium, screenshot_dir):
     ctx = {"name": ""}
     yield ctx
-    if ctx["name"]:
-        selenium.get_screenshot_as_file(f"{screenshot_dir}/{ctx['name']}")
+    if not ctx["name"]:
+        raise ValueError("You forgot to set the final screenshot name!")
+    selenium.get_screenshot_as_file(f"{screenshot_dir}/{ctx['name']}")
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -131,15 +131,11 @@ def screenshot_dir():
 
 
 @pytest.fixture
-def take_final_screenshot(request, selenium, screenshot_dir):
-    yield
-    try:
-        filename = getattr(request.function, "final_screenshot")
-        selenium.get_screenshot_as_file(f"{screenshot_dir}/{filename}")
-    except AttributeError:
-        raise
-    #    # TODO: Emmit warning
-    #    pass
+def final_screenshot(request, selenium, screenshot_dir):
+    ctx = {"name": ""}
+    yield ctx
+    if ctx["name"]:
+        selenium.get_screenshot_as_file(f"{screenshot_dir}/{ctx['name']}")
 
 
 @pytest.fixture

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -25,10 +25,7 @@ def test_dependencies(notebook_service, aiidalab_exec, nb_user):
 
 
 def test_conformer_generation_init(selenium_driver, final_screenshot):
-    driver = selenium_driver(
-        "conformer_generation.ipynb",
-        wait_time=30.0,
-    )
+    driver = selenium_driver("conformer_generation.ipynb", wait_time=30.0)
     final_screenshot["name"] = "conformer-generation-init.png"
     driver.set_window_size(WINDOW_WIDTH, WINDOW_HEIGHT)
     driver.find_element(By.XPATH, "//button[text()='Generate molecule']")
@@ -65,10 +62,9 @@ def test_conformer_generation_steps(
     driver.find_element(By.XPATH, "//button[text()='Download']").click()
 
 
-def test_spectrum_app_init(selenium_driver):
-    driver = selenium_driver(
-        "spectrum_widget.ipynb", wait_time=30.0, screenshot_name="spectrum-widget.png"
-    )
+def test_spectrum_app_init(selenium_driver, final_screenshot):
+    final_screenshot["name"] = "spectrum-app-init.png"
+    driver = selenium_driver("spectrum_widget.ipynb", wait_time=30.0)
     driver.set_window_size(WINDOW_WIDTH, WINDOW_HEIGHT)
     driver.find_element(By.XPATH, "//button[text()='Download spectrum']")
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -24,11 +24,14 @@ def test_dependencies(notebook_service, aiidalab_exec, nb_user):
     aiidalab_exec("pip check", user=nb_user)
 
 
-def test_conformer_generation_init(selenium_driver, screenshot_dir):
-    driver = selenium_driver("conformer_generation.ipynb", wait_time=30.0)
+def test_conformer_generation_init(selenium_driver):
+    driver = selenium_driver(
+        "conformer_generation.ipynb",
+        wait_time=30.0,
+        screenshot_name="conformer-generation-init.png",
+    )
     driver.set_window_size(WINDOW_WIDTH, WINDOW_HEIGHT)
     driver.find_element(By.XPATH, "//button[text()='Generate molecule']")
-    driver.get_screenshot_as_file(f"{screenshot_dir}/conformer-generation-init.png")
 
 
 def test_conformer_generation_steps(
@@ -67,11 +70,11 @@ def test_conformer_generation_steps(
     )
 
 
-def test_spectrum_app_init(selenium_driver, screenshot_dir):
+def test_spectrum_app_init(selenium_driver, take_final_screenshot):
     driver = selenium_driver("spectrum_widget.ipynb", wait_time=30.0)
     driver.set_window_size(WINDOW_WIDTH, WINDOW_HEIGHT)
+    final_screenshot = "spectrum-widget.png"
     driver.find_element(By.XPATH, "//button[text()='Download spectrum']")
-    driver.get_screenshot_as_file(f"{screenshot_dir}/spectrum-widget.png")
 
 
 def test_atmospec_app_init(selenium_driver, screenshot_dir):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -70,10 +70,10 @@ def test_conformer_generation_steps(
     )
 
 
-def test_spectrum_app_init(selenium_driver, take_final_screenshot):
+def test_spectrum_app_init(selenium_driver, final_screenshot):
     driver = selenium_driver("spectrum_widget.ipynb", wait_time=30.0)
     driver.set_window_size(WINDOW_WIDTH, WINDOW_HEIGHT)
-    final_screenshot = "spectrum-widget.png"
+    final_screenshot["name"] = "spectrum-widget.png"
     driver.find_element(By.XPATH, "//button[text()='Download spectrum']")
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -24,18 +24,18 @@ def test_dependencies(notebook_service, aiidalab_exec, nb_user):
     aiidalab_exec("pip check", user=nb_user)
 
 
-def test_conformer_generation_init(selenium_driver):
+def test_conformer_generation_init(selenium_driver, final_screenshot):
     driver = selenium_driver(
         "conformer_generation.ipynb",
         wait_time=30.0,
-        screenshot_name="conformer-generation-init.png",
     )
+    final_screenshot["name"] = "conformer-generation-init.png"
     driver.set_window_size(WINDOW_WIDTH, WINDOW_HEIGHT)
     driver.find_element(By.XPATH, "//button[text()='Generate molecule']")
 
 
 def test_conformer_generation_steps(
-    selenium_driver, screenshot_dir, generate_mol_from_smiles, check_first_atom
+    selenium_driver, final_screenshot, generate_mol_from_smiles, check_first_atom
 ):
     driver = selenium_driver("conformer_generation.ipynb", wait_time=30.0)
     driver.set_window_size(WINDOW_WIDTH, WINDOW_HEIGHT)
@@ -47,9 +47,7 @@ def test_conformer_generation_steps(
     driver.find_element(By.XPATH, "//*[text()='Selection']").click()
     check_first_atom(driver, "C")
 
-    driver.get_screenshot_as_file(
-        f"{screenshot_dir}/conformer-generation-generated.png"
-    )
+    final_screenshot["name"] = "conformer-generation-steps.png"
 
     # Test different generation options
     driver.find_element(By.XPATH, "//option[@value='UFF']").click()
@@ -65,9 +63,6 @@ def test_conformer_generation_steps(
     # Switch to `Download` tab in StructureDataViewer
     driver.find_element(By.XPATH, "//*[text()='Download']").click()
     driver.find_element(By.XPATH, "//button[text()='Download']").click()
-    driver.get_screenshot_as_file(
-        f"{screenshot_dir}/conformer-generation-download-tab.png"
-    )
 
 
 def test_spectrum_app_init(selenium_driver, final_screenshot):
@@ -77,11 +72,11 @@ def test_spectrum_app_init(selenium_driver, final_screenshot):
     driver.find_element(By.XPATH, "//button[text()='Download spectrum']")
 
 
-def test_atmospec_app_init(selenium_driver, screenshot_dir):
+def test_atmospec_app_init(selenium_driver, final_screenshot):
     driver = selenium_driver("atmospec.ipynb", wait_time=30.0)
     driver.set_window_size(WINDOW_WIDTH, WINDOW_HEIGHT)
+    final_screenshot["name"] = "atmospec-app.png"
     driver.find_element(By.XPATH, "//button[text()='Refresh']")
-    driver.get_screenshot_as_file(f"{screenshot_dir}/atmospec-app.png")
 
 
 def test_atmospec_steps(

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -65,10 +65,11 @@ def test_conformer_generation_steps(
     driver.find_element(By.XPATH, "//button[text()='Download']").click()
 
 
-def test_spectrum_app_init(selenium_driver, final_screenshot):
-    driver = selenium_driver("spectrum_widget.ipynb", wait_time=30.0)
+def test_spectrum_app_init(selenium_driver):
+    driver = selenium_driver(
+        "spectrum_widget.ipynb", wait_time=30.0, screenshot_name="spectrum-widget.png"
+    )
     driver.set_window_size(WINDOW_WIDTH, WINDOW_HEIGHT)
-    final_screenshot["name"] = "spectrum-widget.png"
     driver.find_element(By.XPATH, "//button[text()='Download spectrum']")
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,4 +1,5 @@
 import requests
+from pathlib import Path
 
 import pytest
 
@@ -26,7 +27,6 @@ def test_dependencies(notebook_service, aiidalab_exec, nb_user):
 
 def test_conformer_generation_init(selenium_driver, final_screenshot):
     driver = selenium_driver("conformer_generation.ipynb", wait_time=30.0)
-    final_screenshot["name"] = "conformer-generation-init.png"
     driver.set_window_size(WINDOW_WIDTH, WINDOW_HEIGHT)
     driver.find_element(By.XPATH, "//button[text()='Generate molecule']")
 
@@ -43,8 +43,6 @@ def test_conformer_generation_steps(
     # Select the first atom
     driver.find_element(By.XPATH, "//*[text()='Selection']").click()
     check_first_atom(driver, "C")
-
-    final_screenshot["name"] = "conformer-generation-steps.png"
 
     # Test different generation options
     driver.find_element(By.XPATH, "//option[@value='UFF']").click()
@@ -63,7 +61,6 @@ def test_conformer_generation_steps(
 
 
 def test_spectrum_app_init(selenium_driver, final_screenshot):
-    final_screenshot["name"] = "spectrum-app-init.png"
     driver = selenium_driver("spectrum_widget.ipynb", wait_time=30.0)
     driver.set_window_size(WINDOW_WIDTH, WINDOW_HEIGHT)
     driver.find_element(By.XPATH, "//button[text()='Download spectrum']")
@@ -72,12 +69,15 @@ def test_spectrum_app_init(selenium_driver, final_screenshot):
 def test_atmospec_app_init(selenium_driver, final_screenshot):
     driver = selenium_driver("atmospec.ipynb", wait_time=30.0)
     driver.set_window_size(WINDOW_WIDTH, WINDOW_HEIGHT)
-    final_screenshot["name"] = "atmospec-app.png"
     driver.find_element(By.XPATH, "//button[text()='Refresh']")
 
 
 def test_atmospec_steps(
-    selenium_driver, screenshot_dir, generate_mol_from_smiles, check_first_atom
+    selenium_driver,
+    screenshot_dir,
+    final_screenshot,
+    generate_mol_from_smiles,
+    check_first_atom,
 ):
     driver = selenium_driver("atmospec.ipynb", wait_time=40.0)
     driver.set_window_size(WINDOW_WIDTH, WINDOW_HEIGHT)
@@ -85,10 +85,10 @@ def test_atmospec_steps(
     # Generate methane molecule
     generate_mol_from_smiles(driver, "C")
     check_first_atom(driver, "C")
-    driver.get_screenshot_as_file(f"{screenshot_dir}/atmospec-mol-generated.png")
+    driver.get_screenshot_as_file(
+        Path.joinpath(screenshot_dir, "atmospec-steps-mol-generated.png")
+    )
 
     driver.find_element(By.XPATH, "//button[text()='Confirm']").click()
     # Test that we have indeed proceeded to the next step
     driver.find_element(By.XPATH, "//span[contains(.,'✓ Step 1')]")
-
-    driver.get_screenshot_as_file(f"{screenshot_dir}/atmospec-mol-confirmed.png")


### PR DESCRIPTION
A major limitation in the current tests,
when the test fails, it usually doesn't provide any screenshot, and is thus near impossible to debug.

We could solve this by taking the screenshot automatically at the end of the test, regardless whether it failed or not, as part of the test teardown.

Implementing teardown in pytest is described here: https://docs.pytest.org/en/6.2.x/fixture.html#teardown-cleanup-aka-fixture-finalization

Our case is complicated by the fact that we somehow need to pass the screenshot name to the teardown method.

In this commit, we try out two approaches:

1. Having a separate fixture. Screenshot name is passed via a custom variable, which is accessed from the pytest request context via request.function attribute. This is a bit hacky, but keeps this logic separated from other fixtures.

2. Extend the existing selenium_driver fixture with an extra optional parameter.