### PR TITLE
Pin AWB version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,8 +31,7 @@ python_requires = >=3.8
 # at the end we will probably have to do the same thing as aiidalab-qe
 # and publish a separate package to PyPi.
 install_requires =
-    rdkit
-    aiidalab-widgets-base~=2.0.0b0
+    aiidalab-widgets-base[smiles]~=2.0.0b1
     aiida-orca @ git+https://github.com/danielhollas/aiida-orca.git@atmospec
     aiidalab_atmospec_workchain @ file:///home/jovyan/apps/aiidalab-ispg/workflows/
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,8 @@ python_requires = >=3.8
 # at the end we will probably have to do the same thing as aiidalab-qe
 # and publish a separate package to PyPi.
 install_requires =
-    aiidalab-widgets-base[smiles]~=2.0.0b1
+    rdkit
+    aiidalab-widgets-base==2.0.0b0
     aiida-orca @ git+https://github.com/danielhollas/aiida-orca.git@atmospec
     aiidalab_atmospec_workchain @ file:///home/jovyan/apps/aiidalab-ispg/workflows/
 


### PR DESCRIPTION
The new AWB 2.0b1 version breaks the StructureDataViewer and consequently breaks the test suite, so we pin to the last version till this is fixed.