### PR TITLE
Test: Verify that key buttons are enabled/disabled

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -133,6 +133,22 @@ def check_atoms(selenium):
     return _select_atoms
 
 
+@pytest.fixture(scope="session", autouse=True)
+def button_enabled():
+    def _button_enabled(button):
+        assert button.get_attribute("disabled") is None
+
+    return _button_enabled
+
+
+@pytest.fixture(scope="session", autouse=True)
+def button_disabled():
+    def _button_disabled(button):
+        assert button.get_attribute("disabled") == "true"
+
+    return _button_disabled
+
+
 @pytest.fixture(scope="session")
 def screenshot_dir():
     sdir = Path.joinpath(Path.cwd(), "screenshots")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -134,6 +134,11 @@ def test_atmospec_steps(
     driver.set_window_size(WINDOW_WIDTH, WINDOW_HEIGHT)
 
     check_step_status(1, StepState.READY)
+    confirm_structure = WebDriverWait(driver, 10).until(
+        EC.element_to_be_clickable((By.XPATH, "//button[text()='Confirm']"))
+    )
+    # Because we don't have a structure yet, the confirm button should be disabled
+    button_disabled(confirm_structure)
 
     # Generate methane molecule
     generate_mol_from_smiles("C")
@@ -143,15 +148,18 @@ def test_atmospec_steps(
     )
     check_step_status(1, StepState.CONFIGURED)
 
-    confirm = WebDriverWait(driver, 10).until(
-        EC.element_to_be_clickable((By.XPATH, "//button[text()='Confirm']"))
-    )
-    confirm.click()
+    # Confirm structure and go to the next step
+    button_enabled(confirm_structure)
+    confirm_structure.click()
+    button_disabled(confirm_structure)
 
     check_step_status(1, StepState.SUCCESS)
     check_step_status(2, StepState.CONFIGURED)
     check_step_status(3, StepState.INIT)
     check_step_status(4, StepState.INIT)
-    confirm = WebDriverWait(driver, 10).until(
+
+    # Make sure the submit button is visible and enabled
+    submit = WebDriverWait(driver, 10).until(
         EC.element_to_be_clickable((By.XPATH, "//button[text()='Submit']"))
     )
+    button_enabled(submit)


### PR DESCRIPTION
For example, the confirm_structure button should not be enabled when there is no structure.