### PR TITLE
Use pre-commit action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,14 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-      - uses: pre-commit/action@v3.0.0
+      - name: Check out app
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+            python-version: "3.10"
+      - name: Run pre-commit
+        uses: pre-commit/action@v3.0.0
 
 
   test-app:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
             python-version: "3.10"
-            cache: pip
+            cache: "pip"
             cache-dependency-path: |
               **/setup.cfg
               **/pyproject.toml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
             python-version: "3.10"
+            cache: pip
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
 
   test-app:
 
+    needs: pre-commit
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,30 +10,12 @@ on:
 
 jobs:
 
-  # Adapted from: https://github.com/aiidalab/aiidalab-qe
   pre-commit:
-
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v3
-
-      - name: Setup Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
-          cache: pip
-          cache-dependency-path: |
-            .pre-commit-config.yaml
-            **/setup.cfg
-            **/pyproject.toml
-            **/requirements*.txt
-
-      - name: Install dependencies
-        run: python -m pip install pre-commit~=2.20
-
-      - name: Run pre-commit
-        run: pre-commit run --all-files || ( git status --short; git diff; exit 1 )
+      - uses: actions/setup-python@v4
+      - uses: actions/pre-commit/action@v3.0.0
 
 
   test-app:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ jobs:
         with:
             python-version: "3.10"
             cache: pip
+            cache-dependency-path: |
+              **/setup.cfg
+              **/pyproject.toml
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
-      - uses: actions/pre-commit/action@v3.0.0
+      - uses: pre-commit/action@v3.0.0
 
 
   test-app:

--- a/aiidalab_ispg/__init__.py
+++ b/aiidalab_ispg/__init__.py
@@ -17,4 +17,4 @@ __all__ = [
     "ViewSpectrumStep",
 ]
 
-__version__ = "0.2-alpha"
+__version__ = '0.2-alpha'

--- a/aiidalab_ispg/__init__.py
+++ b/aiidalab_ispg/__init__.py
@@ -17,4 +17,4 @@ __all__ = [
     "ViewSpectrumStep",
 ]
 
-__version__ = '0.2-alpha'
+__version__ = "0.2-alpha"


### PR DESCRIPTION
The pre-commit action uses environment caching and thus is roughly twice as fast.
We also now only run tests when pre-commit succeeds.

Closes #126 