### PR TITLE
Bump aiida-orca to 0.7.0

### DIFF
--- a/aiidalab_ispg/app/atmospec_steps.py
+++ b/aiidalab_ispg/app/atmospec_steps.py
@@ -361,6 +361,10 @@ class SubmitAtmospecAppWorkChainStep(SubmitWorkChainStepBase):
             builder.exc.orca.metadata.options.resources["tot_num_mpiprocs"] = 1
             builder.exc.orca.metadata.options.resources["num_mpiprocs_per_machine"] = 1
 
+        # Fetch GBW file from optimization step, to be used as a guess
+        # for subsequent excited state calculations.
+        builder.opt.orca.metadata.options.additional_retrieve_list = ["aiida.gbw"]
+
         # Clean the remote directory by default,
         # we're copying back the main output file and gbw file anyway.
         builder.exc.clean_workdir = Bool(True)
@@ -369,8 +373,11 @@ class SubmitAtmospecAppWorkChainStep(SubmitWorkChainStepBase):
         builder.exc.orca.metadata.description = "ORCA TDDFT calculation"
         builder.opt.orca.metadata.description = "ORCA geometry optimization"
 
+        # TODO: Change bp.geo_opt_type to  bp.optimize and use directly
         if bp.geo_opt_type == "NONE":
             builder.optimize = False
+        else:
+            builder.optimize = True
 
         # Wigner will be sampled only when optimize == True
         builder.nwigner = bp.nwigner

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ python_requires = >=3.8
 # xtb-python is published only via conda-forge so cannot be specified here :-(
 install_requires =
     aiidalab-widgets-base[smiles]~=2.0.0
-    aiida-orca~=0.6.1
+    aiida-orca~=0.7.0
     bokeh~=2.4
 
 [options.extras_require]


### PR DESCRIPTION
Update aiida-orca to v0.7.0, which no longer stores gbw files by default in retrieved folder. 
In our app, we only fetch gbw from the optimization calcjob so that we can use it as a wavefunction guess in subsequent excited state calculations.

Closes #131. 