### PR TITLE
Spectrum fixes

### DIFF
--- a/aiidalab_ispg/app/spectrum.py
+++ b/aiidalab_ispg/app/spectrum.py
@@ -449,10 +449,10 @@ class SpectrumWidget(ipw.VBox):
             node = load_node(self.experimental_spectrum_uuid)
             self.plot_experimental_spectrum(spectrum_node=node, energy_unit=energy_unit)
 
-    def _unhighlight_conformer(self):
-        self.remove_line("conformer_selected")
+    def _unhighlight_conformer(self, update=True):
+        self.remove_line("conformer_selected", update=update)
 
-    def _highlight_conformer(self, conf_id: int):
+    def _highlight_conformer(self, conf_id: int, update=True):
         f = self.figure.get_figure()
         label = f"conformer_{conf_id}"
         if line := f.select_one({"name": label}):
@@ -461,10 +461,12 @@ class SpectrumWidget(ipw.VBox):
             # line.glyph.update(line_dash="solid")
             x = line.data_source.data["x"]
             y = line.data_source.data["y"]
-            self.plot_line(x, y, label="conformer_selected", line_color="red")
+            self.plot_line(
+                x, y, label="conformer_selected", update=update, line_color="red"
+            )
 
     def _hide_all_conformers(self):
-        self._unhighlight_conformer()
+        self._unhighlight_conformer(update=False)
         f = self.figure.get_figure()
         labels = [r.name for r in f.renderers]
         for label in filter(lambda label: label.startswith("conformer_"), labels):
@@ -535,11 +537,11 @@ class SpectrumWidget(ipw.VBox):
         else:
             self.cross_section_nm = [x.tolist(), total_cross_section.tolist()]
 
+        if self.conformer_toggle.value and len(self.conformer_transitions) > 1:
+            self._highlight_conformer(self.selected_conformer_id, update=False)
+
         # Plot total spectrum
         self.plot_line(x, total_cross_section, self.THEORY_SPEC_LABEL, line_width=2)
-
-        if self.conformer_toggle.value and len(self.conformer_transitions) > 1:
-            self._highlight_conformer(self.selected_conformer_id)
 
         if self.stick_toggle.value:
             self.plot_sticks(x_stick, y_stick, self.STICK_SPEC_LABEL)

--- a/aiidalab_ispg/app/spectrum.py
+++ b/aiidalab_ispg/app/spectrum.py
@@ -472,7 +472,8 @@ class SpectrumWidget(ipw.VBox):
         for label in filter(lambda label: label.startswith("conformer_"), labels):
             # NOTE: Hiding does not seem to work
             # Removing without immediate figure update also does not work
-            self.remove_line(label, update=True)
+            self.remove_line(label, update=False)
+        self.figure.update()
 
     def _plot_conformer(self, x, y, conf_id, update=True, line_dash="dashed"):
         line_options = {
@@ -537,11 +538,15 @@ class SpectrumWidget(ipw.VBox):
         else:
             self.cross_section_nm = [x.tolist(), total_cross_section.tolist()]
 
+        # Plot total spectrum
+        self.plot_line(
+            x, total_cross_section, self.THEORY_SPEC_LABEL, update=False, line_width=2
+        )
+
         if self.conformer_toggle.value and len(self.conformer_transitions) > 1:
             self._highlight_conformer(self.selected_conformer_id, update=False)
 
-        # Plot total spectrum
-        self.plot_line(x, total_cross_section, self.THEORY_SPEC_LABEL, line_width=2)
+        self.figure.update()
 
         if self.stick_toggle.value:
             self.plot_sticks(x_stick, y_stick, self.STICK_SPEC_LABEL)
@@ -584,7 +589,7 @@ class SpectrumWidget(ipw.VBox):
         line = f.select_one({"name": label})
         if line is not None:
             # line.data_source.data = {"x": x, "y": y}
-            self.remove_line(label)
+            self.remove_line(label, update=update)
         f.line(x, y, name=label, **args)
         if update:
             self.figure.update()

--- a/aiidalab_ispg/app/spectrum_analysis.py
+++ b/aiidalab_ispg/app/spectrum_analysis.py
@@ -253,7 +253,6 @@ class PhotolysisPlotWidget(ipw.VBox):
         """Observe changes to the spectrum data and update the J plot accordingly.
         Check that fluxdata overlaps with the spectrum data.
         """
-        self.disabled = True
         if change["new"] is None or len(change["new"]) == 0:
             self.reset()
             return
@@ -271,7 +270,6 @@ class PhotolysisPlotWidget(ipw.VBox):
         else:
             self.reset()
             return
-
         self.disabled = False
 
     def _observe_flux_toggle(self, change: dict):
@@ -324,14 +322,15 @@ class PhotolysisPlotWidget(ipw.VBox):
     @tl.observe("disabled")
     def _observe_disabled(self, change: dict):
         disabled = change["new"]
-        if disabled:
-            self.flux_toggle.disabled = True
-            self.yield_slider.disabled = True
-            self.autoscale_yaxis.disabled = True
-        else:
-            self.flux_toggle.disabled = False
-            self.yield_slider.disabled = False
-            self.autoscale_yaxis.disabled = False
+        with self.hold_trait_notifications():
+            if disabled:
+                self.flux_toggle.disabled = True
+                self.yield_slider.disabled = True
+                self.autoscale_yaxis.disabled = True
+            else:
+                self.flux_toggle.disabled = False
+                self.yield_slider.disabled = False
+                self.autoscale_yaxis.disabled = False
 
     def read_actinic_fluxes(self) -> dict:
         """Read in actinic flux data from a CSV file.
@@ -428,7 +427,7 @@ class PhotolysisPlotWidget(ipw.VBox):
         f = self.figure.get_figure()
         line = f.select_one({"name": label})
         if line is not None:
-            self.remove_line(label)
+            self.remove_line(label, update=update)
 
         f.line(x, y, name=label, **args)
         if update:


### PR DESCRIPTION
- Photolysis widget: Refactor plotting

- SpectrumWidget: Reduce jerkiness when redrawing the spectrum 
We had a bug in the plot_line function, where we forgot to pass the update parameter to the remove_line(),
thus always redrawing the spectrum even when called with update=False.
