### PR TITLE
Delayed loading of WorkChain selector widget

### DIFF
--- a/aiidalab_ispg/app/input_widgets.py
+++ b/aiidalab_ispg/app/input_widgets.py
@@ -312,7 +312,6 @@ class CodeSettings(ipw.VBox):
             default_calc_job_plugin="orca.orca",
             description="ORCA program",
         )
-        self._set_default_codes()
         super().__init__(
             children=[
                 self.codes_title,
@@ -321,8 +320,13 @@ class CodeSettings(ipw.VBox):
             ],
             **kwargs,
         )
+        # WARNING: The on_displayed method has been removed in ipywidgets 8.0!!!
+        # https://github.com/jupyter-widgets/ipywidgets/issues/3451
+        # https://github.com/jupyter-widgets/ipywidgets/pull/2021
+        self.on_displayed(self._set_default_codes)
 
-    def _set_default_codes(self):
+    # Extra dummy parameter is needed since this is called via on_displayed
+    def _set_default_codes(self, _=None):
         for code_label in self._DEFAULT_ORCA_CODES:
             try:
                 self.orca.value = load_code(code_label).uuid

--- a/aiidalab_ispg/app/qeapp/process.py
+++ b/aiidalab_ispg/app/qeapp/process.py
@@ -64,8 +64,10 @@ class WorkChainSelector(ipw.HBox):
             ],
             **kwargs,
         )
-
-        self.refresh_work_chains()
+        # WARNING: The on_displayed method has been removed in ipywidgets 8.0!!!
+        # https://github.com/jupyter-widgets/ipywidgets/issues/3451
+        # https://github.com/jupyter-widgets/ipywidgets/pull/2021
+        self.on_displayed(self.refresh_work_chains)
 
     def parse_extra_info(self, pk: int) -> dict:
         """Parse extra information about the work chain."""

--- a/aiidalab_ispg/app/utils.py
+++ b/aiidalab_ispg/app/utils.py
@@ -69,6 +69,9 @@ class BokehFigureContext(ipw.Output):
         super().__init__()
         self._figure = fig
         self._handle = None
+        # WARNING: The on_displayed method has been removed in ipywidgets 8.0!!!
+        # https://github.com/jupyter-widgets/ipywidgets/issues/3451
+        # https://github.com/jupyter-widgets/ipywidgets/pull/2021
         self.on_displayed(lambda x: x.set_handle())
 
     def set_handle(self):


### PR DESCRIPTION
Interacting with AiiDA DB (i.e. loading all the WorkChains in WorkChain selector widget) delays the initial page load. Here we postpone this until after the page is displayed. 

Note the the approach used here is not compatible with ipywidgets==8.0 which removed the `on_displayed` callback. We'll need to figure out something else before we attempt to update.