### PR TITLE
Install xtb and OpenMPI during app installation

### DIFF
--- a/post_install
+++ b/post_install
@@ -11,21 +11,34 @@ set -euo pipefail
 if [[ -z ${ORCA_PATH-} ]]; then
   ORCA_PATH=/opt/orca
 fi
+if [[ ! -d "${ORCA_PATH}" || ! -f "${ORCA_PATH}"/orca ]];then
+  echo "WARNING: Could not find ORCA installation at \"${ORCA_PATH}\", you will need to create a code node on a remote computer."
+  exit 0
+fi
 
 ### CREATE CONDA CHANNEL FOR OPENMPI ###
 if [[ -z ${OPENMPI_VERSION-} ]]; then
   OPENMPI_VERSION=4.1.1
 fi
-CONDA_ENV_NAME="orca-mpi"
-CONDA_ENV_PATH="~/.conda/envs/${CONDA_ENV_NAME}"
 
-mamba create --yes -c conda-forge \
-  --name ${CONDA_ENV_NAME} openmpi=${OPENMPI_VERSION}
-# TODO: AUTODETECT CONDA_ENV_PATH after the environment is created by `mamba env list`
+# Do not create a new env if we already have correct OpenMPI version installed
+CONDA_ENV_PATH="/opt/conda"
+if ! mpirun --version 2>/dev/null | grep -q "Open MPI) ${OPENMPI_VERSION}"; then
+  CONDA_ENV_NAME="orca-mpi"
+  mamba create --yes -c conda-forge \
+    --name ${CONDA_ENV_NAME} openmpi=${OPENMPI_VERSION}
+  CONDA_ENV_PATH=$(mamba env list | grep ${CONDA_ENV_NAME} | awk '{print $NF}')
+  MPIBIN=${CONDA_ENV_PATH}/bin
+  MPILIB=${CONDA_ENV_PATH}/lib
+else
+  mpirun=`which mpirun`
+  MPIBIN=`dirname $mpirun`
+  MPILIB=`dirname $MPIBIN`"/lib"
+  echo "Detected OpenMPI v${OPENMPI_VERSION} in ${MPIBIN}"
+fi
 
-PREPEND_TEXT="conda activate ${CONDA_ENV_NAME};\
-  export PATH=${ORCA_PATH}:${CONDA_ENV_PATH}/bin:\$PATH;\
-  export LD_LIBRARY_PATH=${ORCA_PATH}:${CONDA_ENV_PATH}/lib:\$LD_LIBRARY_PATH"
+PREPEND_TEXT="export PATH=${ORCA_PATH}:${MPIBIN}:\$PATH;\
+  export LD_LIBRARY_PATH=${ORCA_PATH}:${MPILIB}:\$LD_LIBRARY_PATH"
 
 function create_orca_code() {
     computer=$1
@@ -48,11 +61,6 @@ function create_orca_code() {
             --prepend-text "${PREPEND_TEXT}" \
     )
 }
-
-if [[ ! -d "${ORCA_PATH}" || ! -f "${ORCA_PATH}"/orca ]];then
-  echo "WARNING: Could not find ORCA installation at \"${ORCA_PATH}\", you will need to create a code node on a remote computer."
-  exit 0
-fi
 
 # Create orca code node on computer localhost,
 # which is created by default in aiidalab Docker image

--- a/post_install
+++ b/post_install
@@ -20,7 +20,7 @@ CONDA_ENV_NAME="orca-mpi"
 CONDA_ENV_PATH="~/.conda/envs/${CONDA_ENV_NAME}"
 
 mamba create --yes -c conda-forge \
-  --name ${CONDA_ENV_ORCA} openmpi=${OPENMPI_VERSION}
+  --name ${CONDA_ENV_NAME} openmpi=${OPENMPI_VERSION}
 # TODO: AUTODETECT CONDA_ENV_PATH after the environment is created by `mamba env list`
 
 PREPEND_TEXT="conda activate ${CONDA_ENV_NAME};\

--- a/post_install
+++ b/post_install
@@ -1,23 +1,31 @@
 #!/bin/bash
-
+#
 # This script automatically creates required code Nodes in AiiDA database,
 # based on the assumption that the codes are accessible locally.
+# It also install OpenMPI for parallel ORCA execution in a separate conda environment.
+
+set -euo pipefail
 
 # This needs to match the path where you mounted the code!
-# TODO: Perhaps we could autodetermine this via find?
+# TODO: Perhaps we should try to autodetermine this via find?
 if [[ -z ${ORCA_PATH-} ]]; then
   ORCA_PATH=/opt/orca
 fi
-if [[ ! -d "${ORCA_PATH}" || ! -f "${ORCA_PATH}"/orca ]];then
-  echo "WARNING: Could not find ORCA installation at \"${ORCA_PATH}\", you will need to create a code node on a remote computer."
-  exit 0
+
+### CREATE CONDA CHANNEL FOR OPENMPI ###
+if [[ -z ${OPENMPI_VERSION-} ]]; then
+  OPENMPI_VERSION=4.1.1
 fi
+CONDA_ENV_ORCA="orca"
+# TODO: Not sure if this variable is necessary anymore
+OPENMPI_LIB="~/.conda/envs/$CONDA_ENV_ORCA/lib"
 
+conda create --yes --override-channels -c conda-forge \
+  --name ${CONDA_ENV_ORCA} openmpi=${OPENMPI_VERSION}
 
-# We append LD_LIBRARY path since we install OpenMPI
-# via conda in ATMOSPEC Docker image
-# TODO: Detect when OpenMPI is not installed, and (somehow) disable running on multiple CPUs, because that will fail.
-OPENMPI_LIB=/opt/conda/lib
+PREPEND_TEXT="conda activate ${CONDA_ENV_ORCA};\
+  export PATH=${ORCA_PATH}:\$PATH;\
+  export LD_LIBRARY_PATH=${ORCA_PATH}:${OPENMPI_LIB}:\$LD_LIBRARY_PATH"
 
 function create_orca_code() {
     computer=$1
@@ -37,9 +45,14 @@ function create_orca_code() {
             --default-calc-job-plugin ${calcjob} \
             --computer ${computer} \
             --filepath-executable ${ORCA_PATH}/orca \
-            --prepend-text "export PATH=${ORCA_PATH}:\$PATH;export LD_LIBRARY_PATH=${ORCA_PATH}:${OPENMPI_LIB}:\$LD_LIBRARY_PATH" \
+            --prepend-text "${PREPEND_TEXT}" \
     )
 }
+
+if [[ ! -d "${ORCA_PATH}" || ! -f "${ORCA_PATH}"/orca ]];then
+  echo "WARNING: Could not find ORCA installation at \"${ORCA_PATH}\", you will need to create a code node on a remote computer."
+  exit 0
+fi
 
 # Create orca code node on computer localhost,
 # which is created by default in aiidalab Docker image

--- a/post_install
+++ b/post_install
@@ -16,16 +16,16 @@ fi
 if [[ -z ${OPENMPI_VERSION-} ]]; then
   OPENMPI_VERSION=4.1.1
 fi
-CONDA_ENV_ORCA="orca"
-# TODO: Not sure if this variable is necessary anymore
-OPENMPI_LIB="~/.conda/envs/$CONDA_ENV_ORCA/lib"
+CONDA_ENV_NAME="orca-mpi"
+CONDA_ENV_PATH="~/.conda/envs/${CONDA_ENV_NAME}"
 
-conda create --yes --override-channels -c conda-forge \
+mamba create --yes -c conda-forge \
   --name ${CONDA_ENV_ORCA} openmpi=${OPENMPI_VERSION}
+# TODO: AUTODETECT CONDA_ENV_PATH after the environment is created by `mamba env list`
 
-PREPEND_TEXT="conda activate ${CONDA_ENV_ORCA};\
-  export PATH=${ORCA_PATH}:\$PATH;\
-  export LD_LIBRARY_PATH=${ORCA_PATH}:${OPENMPI_LIB}:\$LD_LIBRARY_PATH"
+PREPEND_TEXT="conda activate ${CONDA_ENV_NAME};\
+  export PATH=${ORCA_PATH}:${CONDA_ENV_PATH}/bin:\$PATH;\
+  export LD_LIBRARY_PATH=${ORCA_PATH}:${CONDA_ENV_PATH}/lib:\$LD_LIBRARY_PATH"
 
 function create_orca_code() {
     computer=$1

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,11 +25,13 @@ classifiers =
 [options]
 packages = find:
 python_requires = >=3.9
-# xtb-python is published only via conda-forge so cannot be specified here :-(
 install_requires =
     aiidalab-widgets-base[smiles]~=2.0.0
     aiida-orca~=0.7.0
     bokeh~=2.4
+    xtb~=22.1
+    traitlets~=5.4
+    ipywidgets~=7.7
 
 [options.extras_require]
 dev =


### PR DESCRIPTION
TODO: 
 - [x] Use mamba instead of conda for creating the environment
 - [x] Measure how long does it take to install with mamba. If it takes too long, we might want to still keep it in Atmospec image, but install it only when OpenMPI is not available in the base conda environment (i.e. for users running the vanilla aiidalab-docker-stack image)