### PR TITLE
Fix TrajectoryViewer + enable running CalcJob without RabbitMQ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 *.swp
 *pyc
 *~
-.*.ipynb
+*-[0-9].ipynb
 .DS_Store
 .ipynb_checkpoints/
 .vscode

--- a/aiidalab_ispg/app/input_widgets.py
+++ b/aiidalab_ispg/app/input_widgets.py
@@ -3,7 +3,7 @@
 from enum import Enum, unique
 
 import ipywidgets as ipw
-import traitlets
+import traitlets as tl
 
 from aiida.common import NotExistent
 from aiida.orm import load_code
@@ -240,7 +240,7 @@ class ExcitedStateSettings(ipw.VBox):
 
 
 class WignerSamplingSettings(ipw.VBox):
-    disabled = traitlets.Bool(default=False)
+    disabled = tl.Bool(default=False)
 
     title = ipw.HTML(
         """<div style="padding-top: 0px; padding-bottom: 0px">
@@ -279,7 +279,7 @@ class WignerSamplingSettings(ipw.VBox):
 
         super().__init__([self.title, self.nwigner, self.wigner_low_freq_thr])
 
-    @traitlets.observe("disabled")
+    @tl.observe("disabled")
     def _observer_disabled(self, change):
         if change["new"]:
             self.nwigner.disabled = True
@@ -332,6 +332,11 @@ class CodeSettings(ipw.VBox):
                 self.orca.value = load_code(code_label).uuid
                 return
             except (NotExistent, ValueError):
+                pass
+            except tl.TraitError:
+                # This can happen if one of the code/computers is not configured/enabled or hidden
+                # In practice, this happened to me locally when importing from production DB.
+                # https://github.com/ispg-group/aiidalab-ispg/issues/240
                 pass
 
         if not self.orca.value:

--- a/aiidalab_ispg/app/static/welcome.jinja
+++ b/aiidalab_ispg/app/static/welcome.jinja
@@ -9,7 +9,7 @@
 <div style="padding-top: 0px; padding-bottom: 0px; line-height: 140%;">
   <!--<h3>Welcome to the AiiDAlab ATMOSPEC app! 👋</h3>-->
   <div align="center">
-    <img src="../aiidalab_ispg/app/static/atmospec_logo-480.png" height="70" width=240">
+    <img src="{{ path_to_static }}/atmospec_logo-480.png" height="70" width=240">
   </div>
 
 </div>

--- a/aiidalab_ispg/app/steps.py
+++ b/aiidalab_ispg/app/steps.py
@@ -317,17 +317,14 @@ class ViewSpectrumStep(ipw.VBox, WizardAppWidgetStep):
 
         self.spectrum.conformer_transitions = conformer_transitions
 
-        if "smiles" in process.inputs.structure.extras:
-            self.spectrum.smiles = process.inputs.structure.extras["smiles"]
+        smiles = process.inputs.structure.base.extras.get("smiles", None)
+        self.spectrum.smiles = smiles
+        if smiles:
             # We're attaching smiles extra for the optimized structures as well
             # NOTE: You can distinguish between new / optimized geometries
             # by looking at the 'creator' attribute of the Structure node.
             if "relaxed_structures" in process.outputs:
-                process.outputs.relaxed_structures.base.extras.set(
-                    "smiles", self.spectrum.smiles
-                )
-        else:
-            self.spectrum.smiles = None
+                process.outputs.relaxed_structures.base.extras.set("smiles", smiles)
 
         if process.inputs.optimize:
             assert nconf == len(process.outputs.relaxed_structures.get_stepids())

--- a/aiidalab_ispg/app/widgets.py
+++ b/aiidalab_ispg/app/widgets.py
@@ -245,6 +245,10 @@ class TrajectoryDataViewer(StructureDataViewer):
             self._structures = [
                 trajectory.get_step_structure(i) for i in self.trajectory.get_stepids()
             ]
+            # NOTE: Unfortunately, when converting TrajectoryData to StructureData,
+            # PBC is always set to (True, True, True) so we need to correct.
+            for structure in self._structures:
+                structure.pbc = (False, False, False)
 
             if "energies" in trajectory.get_arraynames():
                 self._energies = trajectory.get_array("energies")

--- a/notebooks/atmospec.ipynb
+++ b/notebooks/atmospec.ipynb
@@ -19,6 +19,7 @@
     "`\n",
     "var styleSheet = document.createElement(\"style\")\n",
     "styleSheet.innerText = styles\n",
+    "\n",
     "document.head.appendChild(styleSheet)\n",
     "\n",
     "document.title = 'AiiDAlab ATMOSPEC app'\n",
@@ -62,9 +63,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os\n",
     "# External imports\n",
     "from jinja2 import Environment\n",
     "from importlib.resources import files\n",
+    "from pathlib import Path\n",
     "\n",
     "from aiida.plugins import DataFactory\n",
     "from aiida.orm import StructureData, TrajectoryData\n",
@@ -174,15 +177,18 @@
     "env = Environment()\n",
     "template = files(static).joinpath(\"welcome.jinja\").read_text()\n",
     "style = files(static).joinpath(\"style.css\").read_text()\n",
+    "# NOTE: The walk_up parameter was only added in Python 3.12,\n",
+    "# so we're using os.path.relpath\n",
+    "# path_to_static = files(static).relative_to(Path.cwd(), walk_up=True)\n",
+    "path_to_static = os.path.relpath(files(static), Path.cwd())\n",
+    "welcome_message = ipw.HTML(env.from_string(template).render(style=style,path_to_static=path_to_static))\n",
     "\n",
-    "welcome_message = ipw.HTML(env.from_string(template).render(style=style,staticpath=files(static)))\n",
-    "\n",
-    "footer = ipw.HBox(\n",
+    "footer = ipw.VBox(\n",
     "    children=[\n",
-    "        ipw.HTML(f'This project has been funded by European Research Council (ERC) grant No. 803718'),\n",
-    "        ipw.HTML(f'Copyright (c) 2022 ISPG team (University of Bristol)&#8195Version: {__version__}'),\n",
+    "        ipw.HTML(f'Funded by ERC grant 803718 SINDAM and EPSRC grant EP/V026690/1 UPDICE.'),\n",
+    "        ipw.HTML(f'© 2024 ISPG team (University of Bristol)&#8195Version: {__version__}'),\n",
     "    ],\n",
-    "    layout=ipw.Layout(justify_content=\"space-between\"),\n",
+    "    #layout=ipw.Layout(justify_content=\"space-between\"),\n",
     ")\n",
     "\n",
     "app_with_work_chain_selector = ipw.VBox(children=[work_chain_selector, app])\n",
@@ -196,13 +202,6 @@
     "loading_message.layout.display = \"none\"\n",
     "display(welcome_message, error_handler_output, app_with_work_chain_selector, footer)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -221,7 +220,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.12.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
TrajectoryData does not track PBC, and so when we
extract StructureData from it, it will have the default
pbc=(True, True,True). Solution is simple, overwrite this.
See:
https://github.com/aiidateam/aiida-core/issues/6376