### PR TITLE
Remove xtb PyPI dependency

### DIFF
--- a/aiidalab_ispg/app/conformers.py
+++ b/aiidalab_ispg/app/conformers.py
@@ -38,7 +38,7 @@ TrajectoryData = DataFactory("core.array.trajectory")
 # Hence, the xTB optimization functionality is optional for now.
 DISABLE_XTB = False
 try:
-    from xtb.ase.calculator import XTB
+    from xtb.ase.calculator import XTB  # ty: ignore[unresolved-import]
 except ImportError:
     print("WARNING: xTB optimization not supported")
     DISABLE_XTB = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
 [options.extras_require]
 test = file: requirements-test.txt
 dev =
-    ty==0.0.70
+    ty==0.0.74
 
 [options.package_data]
 aiidalab_ispg.app.static =

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,6 @@ install_requires =
     aiidalab-widgets-base[smiles]~=2.5.1
     aiida-orca~=0.7.0
     bokeh~=2.4
-    xtb~=22.1
     traitlets~=5.4
     ipywidgets~=7.7
     psutil>=5.9


### PR DESCRIPTION
xtb doesn't have published wheels for Python 3.12, and its build from sdist fails in the AiiDAlab docker image.

We keep the code relying on it for now, as we might be able to keep it installed via conda.